### PR TITLE
Update Execution.py

### DIFF
--- a/CGATCore/Pipeline/Execution.py
+++ b/CGATCore/Pipeline/Execution.py
@@ -585,6 +585,7 @@ def run(**kwargs):
                     ignore_pipe_errors=ignore_pipe_errors),
                 cwd=PARAMS["workingdir"],
                 shell=True,
+                executable="/bin/bash",
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)


### PR DESCRIPTION
Minor change but fixes the Ubuntu + zsh environment.
Otherwise subprocess of python keeps giving `bad substitution error2`.